### PR TITLE
[BREAKING] Change binarySearch / Fix HistoryPercentileCalculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fms-cat/experimental",
   "description": "Experimental edition of FMS_Cat",
   "author": "FMS_Cat",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "dist/fms-cat-experimental.js",
   "module": "dist/fms-cat-experimental.module.js",
   "types": "types/index.d.ts",

--- a/src/HistoryMeanCalculator/tests/HistoryPercentileCalculator.test.ts
+++ b/src/HistoryMeanCalculator/tests/HistoryPercentileCalculator.test.ts
@@ -22,4 +22,16 @@ describe( 'HistoryPercentileCalculator', () => {
     calc.push( 8 );
     expect( calc.median ).toBe( 6 );
   } );
+
+  it( 'should return a median properly (array is fully populated, the first one is the biggest)', () => {
+    const calc = new HistoryPercentileCalculator( 5 );
+    calc.push( 8 );
+    calc.push( 6 );
+    calc.push( 4 );
+    calc.push( 2 );
+    calc.push( 3 );
+    calc.push( 5 );
+    calc.push( 7 );
+    expect( calc.median ).toBeCloseTo( 4 );
+  } );
 } );

--- a/src/algorithm/binarySearch.ts
+++ b/src/algorithm/binarySearch.ts
@@ -1,7 +1,11 @@
 // yoinked from https://stackoverflow.com/questions/1344500/efficient-way-to-insert-a-number-into-a-sorted-array-of-numbers
 
 /**
- * Look for an index from a sorted list using the binary search.
+ * Look for an index from a sorted list using binary search.
+ *
+ * If you don't provide a compare function, it will look for **the first same value** it can find.
+ * If it cannot find an exactly matching value, it can return N where the length of given array is N.
+ *
  * @param array A sorted array
  * @param compare Make this function return `false` if you want to point right side of given element, `true` if you want to point left side of given element.
  * @returns An index found
@@ -13,7 +17,7 @@ export function binarySearch<T>(
   elementOrCompare: T | ( ( element: T ) => boolean ),
 ): number {
   if ( typeof elementOrCompare !== 'function' ) {
-    return binarySearch( array, ( element ) => ( element <= elementOrCompare ) );
+    return binarySearch( array, ( element ) => ( element < elementOrCompare ) );
   }
   const compare = elementOrCompare as ( element: T ) => boolean;
 

--- a/src/algorithm/tests/binarySearch.test.ts
+++ b/src/algorithm/tests/binarySearch.test.ts
@@ -4,12 +4,12 @@ describe( 'binarySearch', () => {
   describe( 'when it uses an element', () => {
     it( 'should find a correct index (has the same value)', () => {
       const result = binarySearch( [ 1, 5, 9, 14, 18 ], 5 );
-      expect( result ).toBe( 2 );
+      expect( result ).toBe( 1 );
     } );
 
     it( 'should find a correct index (has multiple same values)', () => {
       const result = binarySearch( [ 1, 5, 5, 5, 18 ], 5 );
-      expect( result ).toBe( 4 );
+      expect( result ).toBe( 1 );
     } );
 
     it( 'should find a correct index (doesn\'t have a same value)', () => {


### PR DESCRIPTION
`binarySearch` now points the first same value from the sorted array

and also HistoryPercentileCalculator was broken under the certain condition, it's now fixed